### PR TITLE
WAS 실행 프로파일 정리

### DIFF
--- a/jetty-start-with-scouter.bat
+++ b/jetty-start-with-scouter.bat
@@ -1,4 +1,4 @@
 @SETLOCAL
 @CALL .\setenv.bat
 @SET MAVEN_OPTS=-Dscouter.agent.lib=%SCOUTER_JAVA_AGENT_LIB% -Dscouter.config.file=%SCOUTER_JAVA_AGENT_CONF%
-@%LATEST_PROJECT_HOME%\mvnw -f %LATEST_PROJECT_HOME% clean -DskipTests jetty:run -Pwebapp-run-with-scouter
+@%LATEST_PROJECT_HOME%\mvnw -f %LATEST_PROJECT_HOME% clean -DskipTests jetty:run -Pjetty-run-with-scouter

--- a/jetty-start-with-scouter.sh
+++ b/jetty-start-with-scouter.sh
@@ -3,5 +3,5 @@ PROJECT_ROOT=/home/fp024/git-fp024/learning-spring-web-project-by-code
 export $(grep -v '^#' ${PROJECT_ROOT}/setenv.properties | xargs)
 export MAVEN_OPTS="-Dscouter.agent.lib=${SCOUTER_JAVA_AGENT_LIB} -Dscouter.config.file=${SCOUTER_JAVA_AGENT_CONF}"
 cd ${PROJECT_ROOT}/${LATEST_PROJECT_HOME} 
-nohup ./mvnw clean jetty:run -Pwebapp-run-with-scouter 1>${PROJECT_ROOT}/log/board.log 2>&1 &
+nohup ./mvnw clean jetty:run -Pjetty-run-with-scouter 1>${PROJECT_ROOT}/log/board.log 2>&1 &
 ${PROJECT_ROOT}/show-log.sh

--- a/part-last/my-board/pom.xml
+++ b/part-last/my-board/pom.xml
@@ -84,204 +84,6 @@
         </resources>
       </build>
     </profile>
-
-    <!-- 기본 웹 애플리케이션 실행 : jetty 또는 tomcat -->
-    <!-- 부모 pom.xml 에도 있는 설정이지만, 설정을 조금씩 바꿔야할지몰라서 일단은 하위에도 내려놓자~ -->
-    <profile>
-      <id>default-webapp-run</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <!-- Jetty 서버 구동 -->
-          <!-- 도움말 자세히보기: mvnw jetty:help -Ddetail=true -Dgoal=run -->
-          <plugin>
-            <!-- https://www.eclipse.org/jetty/documentation/jetty-10/programming-guide/index.html#jetty-maven-plugin -->
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-maven-plugin</artifactId>
-            <version>${jetty.version}</version>
-            <configuration>
-              <httpConnector>
-                <!--host>localhost</host-->
-                <port>${jetty.port}</port>
-              </httpConnector>
-              <webApp>
-                <contextPath>${jetty-context-path}</contextPath>
-                <descriptor>${web-xml-location}</descriptor>
-                <sessionHandler>
-                  <sessionIdPathParameterName>none</sessionIdPathParameterName>
-                </sessionHandler>
-              </webApp>
-              <deployMode>EMBED</deployMode>
-              <stopKey>CTRL+C</stopKey>
-              <stopPort>8999</stopPort>
-              <!-- 9.x 설정: <scanIntervalSeconds> 대신 <scan> 사용 -->
-              <!--
-                변경 감지 자동 재시작시 ContextLoaderListener가 제대로 실행되지 않는 오류가 발생한다.
-                설정을 -1로하여 자동 재시작이 일어나지 않도록 한다.
-               -->
-              <scan>${jetty-auto-deploy-seconds}</scan>
-              <scanTargetPatterns>
-                <scanTargetPattern>
-                  <directory>src/main/webapp/WEB-INF</directory>
-                  <includes>
-                    <include>**/*.properties</include>
-                    <include>**/*.xml</include>
-                  </includes>
-                  <excludes>
-                    <exclude>**/*.jsp</exclude>
-                  </excludes>
-                </scanTargetPattern>
-              </scanTargetPatterns>
-            </configuration>
-          </plugin>
-
-          <!-- 실제 Tomcat 9 배포 실행 테스트 -->
-          <!-- mvn clean package -DskipTests cargo:run -->
-          <plugin>
-            <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven3-plugin</artifactId>
-            <version>${cargo.version}</version>
-            <configuration>
-              <container>
-                <containerId>${cargo-tomcat.containerId}</containerId>
-                <systemProperties>
-                  <file.encoding>UTF-8</file.encoding>
-                </systemProperties>
-                <zipUrlInstaller>
-                  <url>
-                    https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/${cargo-tomcat.version}/tomcat-${cargo-tomcat.version}.zip
-                  </url>
-                  <downloadDir>${project.build.directory}/downloads</downloadDir>
-                  <extractDir>${project.build.directory}/extracts</extractDir>
-                </zipUrlInstaller>
-              </container>
-              <configuration>
-                <type>standalone</type>
-                <properties>
-                  <cargo.servlet.port>${cargo-server-port}</cargo.servlet.port>
-                </properties>
-              </configuration>
-              <deployables>
-                <deployable>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <type>war</type>
-                  <properties>
-                    <context>${cargo-context-path}</context>
-                  </properties>
-                </deployable>
-              </deployables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- Scouter를 활성화하여 웹 애플리케이션 실행 : jetty 또는 tomcat -->
-    <profile>
-      <id>webapp-run-with-scouter</id>
-      <build>
-        <plugins>
-          <!-- Jetty 서버 구동 -->
-          <!-- 도움말 자세히보기: mvnw jetty:help -Ddetail=true -Dgoal=run -->
-          <plugin>
-            <!-- https://www.eclipse.org/jetty/documentation/jetty-10/programming-guide/index.html#jetty-maven-plugin -->
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-maven-plugin</artifactId>
-            <version>${jetty.version}</version>
-            <configuration>
-              <httpConnector>
-                <!--host>localhost</host-->
-                <port>${jetty.port}</port>
-              </httpConnector>
-              <!-- jvmArgs는 FORK 모드에서만 동작한다. -->
-              <jvmArgs><!--
-                  -->-javaagent:${scouter.agent.lib} <!--
-                  -->--illegal-access=warn <!--
-                  -->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
-                  -->-Djdk.attach.allowAttachSelf=true <!--
-                  -->-Dscouter.config=${project.basedir}/../../${scouter.config.file} <!--
-              --></jvmArgs>
-              <webApp>
-                <contextPath>${jetty-context-path}</contextPath>
-                <descriptor>${web-xml-location}</descriptor>
-                <sessionHandler>
-                  <sessionIdPathParameterName>none</sessionIdPathParameterName>
-                </sessionHandler>
-              </webApp>
-              <deployMode>FORK</deployMode>
-              <stopKey>CTRL+C</stopKey>
-              <stopPort>8999</stopPort>
-              <!-- 9.x 설정: <scanIntervalSeconds> 대신 <scan> 사용 -->
-              <!--
-                변경 감지 자동 재시작시 ContextLoaderListener가 제대로 실행되지 않는 오류가 발생한다.
-                설정을 -1로하여 자동 재시작이 일어나지 않도록 한다.
-               -->
-              <scan>${jetty-auto-deploy-seconds}</scan>
-              <scanTargetPatterns>
-                <scanTargetPattern>
-                  <directory>src/main/webapp/WEB-INF</directory>
-                  <includes>
-                    <include>**/*.properties</include>
-                    <include>**/*.xml</include>
-                  </includes>
-                  <excludes>
-                    <exclude>**/*.jsp</exclude>
-                  </excludes>
-                </scanTargetPattern>
-              </scanTargetPatterns>
-            </configuration>
-          </plugin>
-
-          <!-- 실제 Tomcat 9 배포 실행 테스트 -->
-          <plugin>
-            <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven3-plugin</artifactId>
-            <version>${cargo.version}</version>
-            <configuration>
-              <container>
-                <containerId>${cargo-tomcat.containerId}</containerId>
-                <systemProperties>
-                  <file.encoding>UTF-8</file.encoding>
-                  <scouter.config>${project.basedir}/../../${scouter.config.file}</scouter.config>
-                </systemProperties>
-                <zipUrlInstaller>
-                  <url>
-                    https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/${cargo-tomcat.version}/tomcat-${cargo-tomcat.version}.zip
-                  </url>
-                  <downloadDir>${project.build.directory}/downloads</downloadDir>
-                  <extractDir>${project.build.directory}/extracts</extractDir>
-                </zipUrlInstaller>
-              </container>
-              <configuration>
-                <type>standalone</type>
-                <properties>
-                  <cargo.jvmargs><!--
-                  -->-javaagent:${scouter.agent.lib} <!--
-                  -->--illegal-access=warn <!--
-                  -->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
-                  -->-Djdk.attach.allowAttachSelf=true <!--
-                  --></cargo.jvmargs>
-                  <cargo.servlet.port>${cargo-server-port}</cargo.servlet.port>
-                </properties>
-              </configuration>
-              <deployables>
-                <deployable>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <type>war</type>
-                  <properties>
-                    <context>${cargo-context-path}</context>
-                  </properties>
-                </deployable>
-              </deployables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
   <dependencies>
@@ -372,14 +174,14 @@
       <groupId>jakarta.servlet.jsp.jstl</groupId>
       <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
       <version>${jakarta.servlet.jsp.jstl-api.version}</version>
-      <scope>provided</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
 
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>jakarta.servlet.jsp.jstl</artifactId>
       <version>${jakarta.servlet.jsp.jstl.version}</version>
-      <scope>provided</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
 
     <!-- https://github.com/sargue/java-time-jsptags -->
@@ -590,6 +392,7 @@
         </executions>
       </plugin>
       -->
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/part01/ex00/pom.xml
+++ b/part01/ex00/pom.xml
@@ -80,7 +80,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc11/ -->
     <dependency>

--- a/part01/jex00/pom.xml
+++ b/part01/jex00/pom.xml
@@ -68,7 +68,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- Database -->
     <!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc11/ -->

--- a/part02/ex01/pom.xml
+++ b/part02/ex01/pom.xml
@@ -72,7 +72,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
     <dependency>

--- a/part02/jex01/pom.xml
+++ b/part02/jex01/pom.xml
@@ -73,7 +73,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- lombok  -->
     <dependency>

--- a/part03/ex02/pom.xml
+++ b/part03/ex02/pom.xml
@@ -90,7 +90,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
 
     <!-- https://github.com/sargue/java-time-jsptags -->

--- a/part03/jex02/pom.xml
+++ b/part03/jex02/pom.xml
@@ -85,7 +85,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://github.com/sargue/java-time-jsptags -->
     <dependency>

--- a/part04/ex03/pom.xml
+++ b/part04/ex03/pom.xml
@@ -84,7 +84,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://github.com/sargue/java-time-jsptags -->
     <dependency>

--- a/part04/jex03/pom.xml
+++ b/part04/jex03/pom.xml
@@ -85,7 +85,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://github.com/sargue/java-time-jsptags -->
     <dependency>

--- a/part05/ex04-board/pom.xml
+++ b/part05/ex04-board/pom.xml
@@ -84,7 +84,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://github.com/sargue/java-time-jsptags -->
     <dependency>

--- a/part05/ex04/pom.xml
+++ b/part05/ex04/pom.xml
@@ -85,7 +85,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
 
     <!-- Database -->

--- a/part05/jex04-board/pom.xml
+++ b/part05/jex04-board/pom.xml
@@ -85,7 +85,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://github.com/sargue/java-time-jsptags -->
     <dependency>

--- a/part05/jex04/pom.xml
+++ b/part05/jex04/pom.xml
@@ -82,7 +82,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- lombok  -->
     <dependency>

--- a/part06/ex05-board/pom.xml
+++ b/part06/ex05-board/pom.xml
@@ -130,7 +130,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://github.com/sargue/java-time-jsptags -->
     <dependency>

--- a/part06/ex05/pom.xml
+++ b/part06/ex05/pom.xml
@@ -117,7 +117,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- 파일 업로드 -->
     <!-- Servlet 4.0을 지원하는 WAS를 사용하므로, commons-fileupload는 사용하지 않는다. -->

--- a/part06/jex05-board/pom.xml
+++ b/part06/jex05-board/pom.xml
@@ -130,7 +130,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- https://github.com/sargue/java-time-jsptags -->
     <dependency>

--- a/part06/jex05/pom.xml
+++ b/part06/jex05/pom.xml
@@ -120,7 +120,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- lombok  -->
     <dependency>

--- a/part07/ex06-board/pom.xml
+++ b/part07/ex06-board/pom.xml
@@ -136,7 +136,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
 
     <!-- https://github.com/sargue/java-time-jsptags -->

--- a/part07/ex06/pom.xml
+++ b/part07/ex06/pom.xml
@@ -131,7 +131,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- lombok  -->
     <dependency>

--- a/part07/jex06-board/pom.xml
+++ b/part07/jex06-board/pom.xml
@@ -165,7 +165,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
 
     <!-- https://github.com/sargue/java-time-jsptags -->

--- a/part07/jex06/pom.xml
+++ b/part07/jex06/pom.xml
@@ -142,7 +142,7 @@
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
       <version>${jstl.version}</version>
-      <scope>runtime</scope>
+      <scope>${jstl-scope.type}</scope>
     </dependency>
     <!-- lombok  -->
     <dependency>

--- a/study-dependencies-parent/pom.xml
+++ b/study-dependencies-parent/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.fp024</groupId>
   <artifactId>study-dependencies-parent</artifactId>
@@ -87,6 +89,9 @@
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
 
+    <!-- Jetty일 때는 provided, Tomcat일 때는 compile로 설정하기위해 프로퍼티로 분리했다. -->
+    <jstl-scope.type>provided</jstl-scope.type>
+    
     <!-- Jetty Http 포트 기본값 -->
     <jetty.port>8080</jetty.port>
     <!-- Jetty Context Path 설정 기본값 -->
@@ -139,13 +144,16 @@
     </dependencies>
   </dependencyManagement>
 
-  <!-- 기본 웹 애플리케이션 실행 : jetty 또는 tomcat -->
   <profiles>
+    <!-- Jetty 기본 웹 애플리케이션 실행  -->
     <profile>
-      <id>default-webapp-run</id>
+      <id>jetty-run</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <properties>
+        <jstl-scope.type>provided</jstl-scope.type>
+      </properties>
       <build>
         <plugins>
           <!-- Jetty 서버 구동 -->
@@ -155,7 +163,7 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>
             <version>${jetty.version}</version>
-            <configuration>          
+            <configuration>
               <httpConnector>
                 <!--host>localhost</host-->
                 <port>${jetty.port}</port>
@@ -189,24 +197,20 @@
                 </scanTargetPattern>
               </scanTargetPatterns>
             </configuration>
-            <!--
-            <dependencies>
-              <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>apache-jstl</artifactId>
-                <version>${apache-jstl.version}</version>
-                <exclusions>
-                  <exclusion>
-                    <groupId>org.apache.taglibs</groupId>
-                    <artifactId>taglibs-standard-impl</artifactId>
-                  </exclusion>
-                </exclusions>
-              </dependency>
-            </dependencies>
-            -->
           </plugin>
-          
-          <!-- 실제 Tomcat 9 배포 실행 테스트 -->
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Tomcat 기본 웹 애플리케이션 실행  -->
+    <profile>
+      <id>tomcat-run</id>
+      <properties>
+        <jstl-scope.type>compile</jstl-scope.type>
+      </properties>
+      <build>
+        <plugins>
+          <!-- 실제 Tomcat 배포 실행 테스트 -->
           <!-- mvn clean package -DskipTests cargo:run -->
           <plugin>
             <groupId>org.codehaus.cargo</groupId>
@@ -219,7 +223,9 @@
                   <file.encoding>UTF-8</file.encoding>
                 </systemProperties>
                 <zipUrlInstaller>
-                  <url>https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/${cargo-tomcat.version}/tomcat-${cargo-tomcat.version}.zip</url>
+                  <url>
+                    https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/${cargo-tomcat.version}/tomcat-${cargo-tomcat.version}.zip
+                  </url>
                   <downloadDir>${project.build.directory}/downloads</downloadDir>
                   <extractDir>${project.build.directory}/extracts</extractDir>
                 </zipUrlInstaller>
@@ -245,10 +251,13 @@
         </plugins>
       </build>
     </profile>
-  
-    <!-- Scouter를 활성화하여 웹 애플리케이션 실행 : jetty 또는 tomcat -->
+
+    <!-- Jetty - Scouter를 활성화하여 웹 애플리케이션 실행 -->
     <profile>
-      <id>webapp-run-with-scouter</id>
+      <id>jetty-run-with-scouter</id>
+      <properties>
+        <jstl-scope.type>provided</jstl-scope.type>
+      </properties>
       <build>
         <plugins>
           <!-- Jetty 서버 구동 -->
@@ -258,7 +267,7 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>
             <version>${jetty.version}</version>
-            <configuration>          
+            <configuration>
               <httpConnector>
                 <!--host>localhost</host-->
                 <port>${jetty.port}</port>
@@ -300,22 +309,20 @@
                 </scanTargetPattern>
               </scanTargetPatterns>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>apache-jstl</artifactId>
-                <version>${jetty.version}</version>
-                <exclusions>
-                  <exclusion>
-                    <groupId>org.apache.taglibs</groupId>
-                    <artifactId>taglibs-standard-impl</artifactId>
-                  </exclusion>
-                </exclusions>
-              </dependency>
-            </dependencies>
           </plugin>
+        </plugins>
+      </build>
+    </profile>
 
-          <!-- 실제 Tomcat 9 배포 실행 테스트 -->
+    <!-- Tomcat - Scouter를 활성화하여 웹 애플리케이션 실행 -->
+    <profile>
+      <id>tomcat-run-with-scouter</id>
+      <properties>
+        <jstl-scope.type>compile</jstl-scope.type>
+      </properties>
+      <build>
+        <plugins>
+          <!-- 실제 Tomcat  배포 실행 테스트 -->
           <plugin>
             <groupId>org.codehaus.cargo</groupId>
             <artifactId>cargo-maven3-plugin</artifactId>
@@ -328,7 +335,9 @@
                   <scouter.config>${project.basedir}/../../${scouter.config.file}</scouter.config>
                 </systemProperties>
                 <zipUrlInstaller>
-                  <url>https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/${cargo-tomcat.version}/tomcat-${cargo-tomcat.version}.zip</url>
+                  <url>
+                    https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/${cargo-tomcat.version}/tomcat-${cargo-tomcat.version}.zip
+                  </url>
                   <downloadDir>${project.build.directory}/downloads</downloadDir>
                   <extractDir>${project.build.directory}/extracts</extractDir>
                 </zipUrlInstaller>
@@ -359,7 +368,7 @@
           </plugin>
         </plugins>
       </build>
-    </profile>    
+    </profile>
   </profiles>
 
   <build>
@@ -390,7 +399,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                     <!-- Eclipse m2e 동작에서는 무시 처리 -->
                   </action>
                 </pluginExecution>
@@ -404,7 +413,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
         </plugin>
-        
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>

--- a/tomcat-start-with-scouter.bat
+++ b/tomcat-start-with-scouter.bat
@@ -1,4 +1,4 @@
 @SETLOCAL
 @CALL .\setenv.bat
 @SET MAVEN_OPTS=-Dscouter.agent.lib=%SCOUTER_JAVA_AGENT_LIB% -Dscouter.config.file=%SCOUTER_JAVA_AGENT_CONF%
-@%LATEST_PROJECT_HOME%\mvnw -f %LATEST_PROJECT_HOME% clean package -DskipTests cargo:run -Pwebapp-run-with-scouter
+@%LATEST_PROJECT_HOME%\mvnw -f %LATEST_PROJECT_HOME% clean package -DskipTests cargo:run -Ptomcat-run-with-scouter

--- a/tomcat-start-with-scouter.sh
+++ b/tomcat-start-with-scouter.sh
@@ -12,4 +12,4 @@ cd ${PROJECT_ROOT}/${LATEST_PROJECT_HOME}
 #
 # Tomcat은 nohup로 백그라운드 실행하지말고 직접 실행하는 것이 낫겠다.
 
-./mvnw clean package -DskipTests cargo:run -Pwebapp-run-with-scouter
+./mvnw clean package -DskipTests cargo:run -Ptomcat-run-with-scouter


### PR DESCRIPTION
1. JSTL 라이브러리에 대해, Tomcat은 compile, Jetty는 Provided로 처리 Maven 프로필을 설정함.

2. WAS 실행 프로필을 4가지로 분리
   1. Jetty 실행
      mvnw clean jetty:run   (기본 프로필이라 프로필 정하지 않아도 됨)
   2. Scouter 적용하여 Jetty 실행
      mvnw -Pjetty-run-with-scouter clean jetty:run 가 기본 명령인데, 추가 옵션을 전달해야되서, 프로젝트 루트의 배치파일을 실행할 것.
   3. Tomcat 실행
      mvnw  -DskipTests -Ptomcat-run clean package cargo:run
   4. Scouter 적용하여 Tomcat 실행
      mvnw  -DskipTests -Ptomcat-run-with-scouter clean package cargo:run 가 기본 명령인데, 추가 옵션을 전달해야되서, 프로젝트 루트의 배치파일을 실행할 것.

3. Scouter 적용 실행 배치파일 변경 모든걸 최신으로 업그레이드한 my-board 프로젝트는 데이터 수집이 제대로 안된다. ㅠㅠ Xlog 점이 안찍힘...